### PR TITLE
Patch 2

### DIFF
--- a/src/Pellmonsrv/plugins/calculate/__init__.py
+++ b/src/Pellmonsrv/plugins/calculate/__init__.py
@@ -168,6 +168,14 @@ class Calc():
                 self.stack.append(gstore[var])
             except:
                 raise ValueError('no global named %s'%var)
+        elif c == 'str==':
+            item2 = self.stack.pop()
+            item1 = self.stack.pop()
+            self.stack.append(unicode(int(str(item1) == str(item2))))
+        elif c == 'str!=':
+            item2 = self.stack.pop()
+            item1 = self.stack.pop()
+            self.stack.append(unicode(int(str(item1) != str(item2))))
         else:
             self.stack.append(c)
         self.IP += 1

--- a/src/conf.d/plugins/calculate.conf
+++ b/src/conf.d/plugins/calculate.conf
@@ -8,7 +8,7 @@
 # xxx_progtype = R|R/W, default is R (read only). An R/W program item can be edited in the web frontend and can be used by other programs as a variable by using get/set
 
 # Available instructions:
-# +, -, *, /, get, set, exec, >, <, ==, !=, ?, min, max, pop, dup, swap, sp, def, sto, rcl, del, gdef, gsto, grcl, gdel, if..then..[else]..end
+# +, -, *, /, get, set, exec, >, <, ==, !=, ?, min, max, pop, dup, swap, sp, def, sto, rcl, del, gdef, gsto, grcl, gdel, str==, str!=, if..then..[else]..end
 # 'get' pops an item name, reads the value and pushes the value or 'error'
 # 'set' pops an item name and a value, then writes the value to the item name and pushes the result 'OK' or 'error'. ex: "1250 feeder_capacity set"
 # ? pops three values, first the value to push back when False, then the value to push back when True, and then the value to evaluate. Ex: "0 123 456 ?" will leave "456" on the stack, while "1 123 456 ?" will leave "123" on the stack
@@ -24,6 +24,8 @@
 # 'rcl' pops one value which identifies a local variable to read and pushes it's value back to the stack
 # 'del' pops one value which identifies a local variable to delete
 # gdef, gsto, grcl, gdel works exactly as def, sto, rcl, del, except that they handle global variables that persist between program executions and are available to all programs.
+# 'str==' pops two values and compares them as strings, returning true if they are equal
+# 'str!=' pops two values and compares them as strings, returning true if they are different
 # 'if' marks the start of an if..then..[else]..end clause. 'then' pops a value, if it is non-zero, execution is continued until 'else|end'. If 'else' is found execution skips forward until 'end' is found. If 'then' pops a zero from the stack, execution skips forward until 'else|end' is found and then resumes
 
 # example: get boiler temperature divided by two from an item named 'half_boiler_temp'


### PR DESCRIPTION
-suggestion to add two new commands to the calculate module 'str==' and 'str!=' which are extremely helpfull to detect for instance errors returned by the onewire plugin. If that module gets an error reading a temperature it returns the string 'error' which cannot be detected with existing commands in the calculate module.
-Adding description for the two new proposed commands 'str==' and 'str!='