### PR TITLE
Show current timer status of Scotte burners and display it in system image.

### DIFF
--- a/src/Pellmonsrv/plugins/scottecom/Makefile.am
+++ b/src/Pellmonsrv/plugins/scottecom/Makefile.am
@@ -2,6 +2,7 @@ scottecom_PYTHON = \
 	datamenu.py \
 	descriptions.py \
 	menus.py \
+	timerstatus.py \
 	scottecom.py \
 	__init__.py 
 

--- a/src/Pellmonsrv/plugins/scottecom/scottecom.py
+++ b/src/Pellmonsrv/plugins/scottecom/scottecom.py
@@ -23,6 +23,7 @@ from Pellmonsrv.plugin_categories import protocols
 from Pellmonsrv.database import Item, Getsetitem
 import menus
 from descriptions import dataDescriptions
+import timerstatus
 
 class scottecom(protocols):
     def __init__(self):
@@ -79,6 +80,14 @@ class scottecom(protocols):
             self.dataDescriptions = dataDescriptions
         except:
             self.logger.info('scottecom protocol setup failed')
+
+        self.registerTimerStatus()
+
+    def registerTimerStatus(self):
+        """Register timer_status item."""
+        timerstatus_item = timerstatus.get_item(self.db)
+        self.db.insert(timerstatus_item)
+        self.itemrefs.append(timerstatus_item)
 
     def getItem(self, item, raw=False):
         return self.protocol.getItem(item, raw)

--- a/src/Pellmonsrv/plugins/scottecom/timerstatus.py
+++ b/src/Pellmonsrv/plugins/scottecom/timerstatus.py
@@ -1,0 +1,40 @@
+from Pellmonsrv.database import Getsetitem
+from Scotteprotocol.transformations import minutes_to_time
+
+
+def get_item(db):
+    i = Getsetitem('timer_status', '-', getter = lambda item: get_item_value(db, item))
+    i.longname = 'timer status'
+    i.type = 'R'
+    i.description = 'Inferred timer status'
+    i.tags = ['Basic', 'Overview', 'Timer']
+    return i
+
+def get_item_value(db, item):
+    current_time = from_time(db.get_value("time_minutes"))
+    period = from_time(db.get_value("timer_heating_period"))
+    starts = [from_time(db.get_value("timer_heating_start_%d" % i)) for i in range(1, 5)]
+    return get_status_text(starts, period, current_time)
+
+def from_time(s):
+    return int(minutes_to_time().encode(s))
+
+def to_time(minutes):
+    return minutes_to_time().decode(minutes)
+
+def get_status_text(starts, period, current_time):
+    starts = sorted(filter(lambda x: x != 0, starts))
+    if len(starts) == 0 or period == 0:
+        return "Timer disabled"
+
+    next_start = None
+    for start in starts:
+        if current_time > start and current_time < start + period:
+            return "Stopping at %s" % to_time(start + period)
+        if start > current_time:
+            next_start = start
+            break
+    if next_start is None:
+        next_start = starts[0]
+    return "Starting at %s" % to_time(next_start)
+

--- a/src/Pellmonweb/media/img/system_nbe.svg
+++ b/src/Pellmonweb/media/img/system_nbe.svg
@@ -13,7 +13,7 @@
    id="svg2"
    version="1.1"
    viewBox="0 0 440 280"
-   inkscape:version="0.48.4 r9939"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="system_nbe.svg"
    width="100%"
    height="100%">
@@ -342,12 +342,12 @@
      fit-margin-right="0"
      fit-margin-bottom="0"
      inkscape:zoom="2.8284273"
-     inkscape:cx="278.0963"
-     inkscape:cy="73.681692"
-     inkscape:window-width="1280"
-     inkscape:window-height="1000"
+     inkscape:cx="263.95417"
+     inkscape:cy="186.81877"
+     inkscape:window-width="1440"
+     inkscape:window-height="851"
      inkscape:window-x="0"
-     inkscape:window-y="24"
+     inkscape:window-y="1"
      showguides="true"
      inkscape:guide-bbox="true" />
   <metadata
@@ -358,7 +358,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -823,7 +823,7 @@
        sodipodi:cy="166.9174"
        sodipodi:rx="6.6519175"
        sodipodi:ry="6.6519175"
-       d="m 179.11505,166.9174 a 6.6519175,6.6519175 0 1 1 -13.30383,0 6.6519175,6.6519175 0 1 1 13.30383,0 z"
+       d="m 179.11505,166.9174 a 6.6519175,6.6519175 0 0 1 -6.65192,6.65192 6.6519175,6.6519175 0 0 1 -6.65191,-6.65192 6.6519175,6.6519175 0 0 1 6.65191,-6.65191 6.6519175,6.6519175 0 0 1 6.65192,6.65191 z"
        transform="matrix(1.2207615,0,0,1.2487627,-40.486359,51.647051)" />
     <text
        sodipodi:linespacing="125%"
@@ -1026,5 +1026,44 @@
          id="tspan3836"
          x="306.0311"
          y="177.85207">State:</tspan></text>
+    <g
+       id="g5403"
+       transform="translate(106.95331,8)">
+      <text
+         inkscape:label="#text3836"
+         transform="scale(0.9587576,1.0430165)"
+         sodipodi:linespacing="100%"
+         id="paramname:timer_status"
+         y="139.88612"
+         x="242.59431"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.91125011px;line-height:100%;font-family:Alarm;-inkscape-font-specification:'Alarm, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.91125011px;line-height:100%;font-family:Alarm;-inkscape-font-specification:'Alarm, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start"
+           y="139.88612"
+           x="242.59431"
+           id="tspan3023-5"
+           sodipodi:role="line">---</tspan></text>
+      <ellipse
+         ry="5.8925047"
+         rx="5.7602162"
+         cy="-141.56596"
+         cx="220.69708"
+         transform="scale(1,-1)"
+         id="path3084-5"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.82574874;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <ellipse
+         ry="0.75994557"
+         rx="1.723376"
+         cy="134.57516"
+         cx="220.69708"
+         id="path3084-5-8"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.52600002;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path4334"
+         d="m 223.62523,140.33959 -3.02763,1.51382 -1.00921,3.53223"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.69999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
   </g>
 </svg>

--- a/src/Pellmonweb/media/img/system_nbe_2w.svg
+++ b/src/Pellmonweb/media/img/system_nbe_2w.svg
@@ -13,7 +13,7 @@
    id="svg2"
    version="1.1"
    viewBox="0 0 440 280"
-   inkscape:version="0.48.4 r9939"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="system_nbe_2w.svg"
    width="100%"
    height="100%">
@@ -335,21 +335,25 @@
      inkscape:pageshadow="2"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
-     showgrid="false"
+     showgrid="true"
      inkscape:window-maximized="1"
      fit-margin-top="0"
      fit-margin-left="0"
      fit-margin-right="0"
      fit-margin-bottom="0"
      inkscape:zoom="2.0000001"
-     inkscape:cx="175.09174"
-     inkscape:cy="108.70897"
-     inkscape:window-width="1280"
-     inkscape:window-height="1000"
+     inkscape:cx="188.59174"
+     inkscape:cy="168.70897"
+     inkscape:window-width="1440"
+     inkscape:window-height="851"
      inkscape:window-x="0"
-     inkscape:window-y="24"
+     inkscape:window-y="1"
      showguides="true"
-     inkscape:guide-bbox="true" />
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid8058" />
+  </sodipodi:namedview>
   <metadata
      id="metadata7">
     <rdf:RDF>
@@ -827,7 +831,7 @@
        sodipodi:cy="166.9174"
        sodipodi:rx="6.6519175"
        sodipodi:ry="6.6519175"
-       d="m 179.11505,166.9174 c 0,3.67376 -2.97816,6.65192 -6.65192,6.65192 -3.67375,0 -6.65191,-2.97816 -6.65191,-6.65192 0,-3.67375 2.97816,-6.65191 6.65191,-6.65191 3.67376,0 6.65192,2.97816 6.65192,6.65191 z"
+       d="m 179.11505,166.9174 a 6.6519175,6.6519175 0 0 1 -6.65192,6.65192 6.6519175,6.6519175 0 0 1 -6.65191,-6.65192 6.6519175,6.6519175 0 0 1 6.65191,-6.65191 6.6519175,6.6519175 0 0 1 6.65192,6.65191 z"
        transform="matrix(1.2207615,0,0,1.2487627,-40.486359,51.647051)" />
     <text
        sodipodi:linespacing="125%"
@@ -1069,5 +1073,44 @@
          id="tspan3836"
          x="306.0311"
          y="177.85207">State:</tspan></text>
+    <g
+       id="g5403"
+       transform="translate(106.49999,6.4999996)">
+      <text
+         inkscape:label="#text3836"
+         transform="scale(0.9587576,1.0430165)"
+         sodipodi:linespacing="100%"
+         id="paramname:timer_status"
+         y="139.88612"
+         x="242.59431"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.91125011px;line-height:100%;font-family:Alarm;-inkscape-font-specification:'Alarm, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.91125011px;line-height:100%;font-family:Alarm;-inkscape-font-specification:'Alarm, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start"
+           y="139.88612"
+           x="242.59431"
+           id="tspan3023-5"
+           sodipodi:role="line">---</tspan></text>
+      <ellipse
+         ry="5.8925047"
+         rx="5.7602162"
+         cy="-141.56596"
+         cx="220.69708"
+         transform="scale(1,-1)"
+         id="path3084-5"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.82574874;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <ellipse
+         ry="0.75994557"
+         rx="1.723376"
+         cy="134.57516"
+         cx="220.69708"
+         id="path3084-5-8"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.52600002;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path4334"
+         d="m 223.62523,140.33959 -3.02763,1.51382 -1.00921,3.53223"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.69999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
   </g>
 </svg>

--- a/src/Pellmonweb/media/img/system_nbe_3w.svg
+++ b/src/Pellmonweb/media/img/system_nbe_3w.svg
@@ -13,7 +13,7 @@
    id="svg2"
    version="1.1"
    viewBox="0 0 440 280"
-   inkscape:version="0.48.4 r9939"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="system_nbe_3w.svg"
    width="100%"
    height="100%">
@@ -336,18 +336,18 @@
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
-     inkscape:window-maximized="1"
+     inkscape:window-maximized="0"
      fit-margin-top="0"
      fit-margin-left="0"
      fit-margin-right="0"
      fit-margin-bottom="0"
-     inkscape:zoom="0.70710685"
-     inkscape:cx="426.26476"
-     inkscape:cy="71.348478"
-     inkscape:window-width="1280"
-     inkscape:window-height="1000"
-     inkscape:window-x="0"
-     inkscape:window-y="24"
+     inkscape:zoom="4.0000004"
+     inkscape:cx="278.60981"
+     inkscape:cy="223.87941"
+     inkscape:window-width="1440"
+     inkscape:window-height="851"
+     inkscape:window-x="138"
+     inkscape:window-y="185"
      showguides="true"
      inkscape:guide-bbox="true" />
   <metadata
@@ -858,7 +858,7 @@
        sodipodi:cy="166.9174"
        sodipodi:rx="6.6519175"
        sodipodi:ry="6.6519175"
-       d="m 179.11505,166.9174 c 0,3.67376 -2.97816,6.65192 -6.65192,6.65192 -3.67375,0 -6.65191,-2.97816 -6.65191,-6.65192 0,-3.67375 2.97816,-6.65191 6.65191,-6.65191 3.67376,0 6.65192,2.97816 6.65192,6.65191 z"
+       d="m 179.11505,166.9174 a 6.6519175,6.6519175 0 0 1 -6.65192,6.65192 6.6519175,6.6519175 0 0 1 -6.65191,-6.65192 6.6519175,6.6519175 0 0 1 6.65191,-6.65191 6.6519175,6.6519175 0 0 1 6.65192,6.65191 z"
        transform="matrix(1.2207615,0,0,1.2487627,-40.486359,51.647051)" />
     <text
        sodipodi:linespacing="125%"
@@ -1096,6 +1096,45 @@
          id="tspan3052"
          x="476.68286"
          y="-72.57592">g/360s</tspan></text>
+    <g
+       id="g5403"
+       transform="translate(108.37971,6)">
+      <text
+         inkscape:label="#text3836"
+         transform="scale(0.9587576,1.0430165)"
+         sodipodi:linespacing="100%"
+         id="paramname:timer_status"
+         y="139.88612"
+         x="242.59431"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.91125011px;line-height:100%;font-family:Alarm;-inkscape-font-specification:'Alarm, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.91125011px;line-height:100%;font-family:Alarm;-inkscape-font-specification:'Alarm, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start"
+           y="139.88612"
+           x="242.59431"
+           id="tspan3023-5"
+           sodipodi:role="line">---</tspan></text>
+      <ellipse
+         ry="5.8925047"
+         rx="5.7602162"
+         cy="-141.56596"
+         cx="220.69708"
+         transform="scale(1,-1)"
+         id="path3084-5"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.82574874;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <ellipse
+         ry="0.75994557"
+         rx="1.723376"
+         cy="134.57516"
+         cx="220.69708"
+         id="path3084-5-8"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.52600002;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path4334"
+         d="m 223.62523,140.33959 -3.02763,1.51382 -1.00921,3.53223"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.69999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
     <flowRoot
        xml:space="preserve"
        id="flowRoot4562"
@@ -1106,5 +1145,5 @@
            height="52.325897"
            x="277.18582"
            y="38.87661" /></flowRegion><flowPara
-         id="flowPara4568"></flowPara></flowRoot>  </g>
+         id="flowPara4568" /></flowRoot>  </g>
 </svg>


### PR DESCRIPTION
So, I thought it would be useful to have an overview of what is going on on the system image when using the Scotte built-in timer to start/stop the burner.

The plugin sets the item called `timer_status` with a string, which is calculated based on `time_minutes` and `timer_heating_period` and the `timer_heating__start_X` settings.

If it is not currently within a timer period, then it determines when the burner is set to start ("Starting at ...").
Otherwise, it tries to determine when the next time the burner is set to stop according to the timer ("Stopping at ...").
If period is not set (0), then it says "Timer disabled".

The value has been added to the default system image.
The plugin has been enabled by default (don't know if that's a good idea).

<img width="593" alt="screen shot 2018-05-16 at 23 06 11" src="https://user-images.githubusercontent.com/5605897/40146240-13beb156-5965-11e8-8796-f066d35b82a4.png">

Not sure if it belongs in a separate plugin, but I didn't know where else it should fit in.